### PR TITLE
fix: Umsetzen des Aktiv-Zeiger entfernt

### DIFF
--- a/game/src/main/java/net/driftingsouls/ds2/server/modules/ks/KSGroupAttackAction.java
+++ b/game/src/main/java/net/driftingsouls/ds2/server/modules/ks/KSGroupAttackAction.java
@@ -64,7 +64,9 @@ public class KSGroupAttackAction extends BasicKSAction {
         for(BattleShip aship : togoShips)
         {
             BattleShip enemyShip = battle.getEnemyShip();
-            battle.setFiringShip(aship.getShip());
+            //Die Funktion "setFiringShip" setzt lediglich den Zeiger des aktiven Schiffs weiter. Das braucht man mMn nicht, da alles hier ueber die Schleife 
+            //gesteuert wird. Durch das Umsetzen des Zeigers wird lediglich das letzte Schiff der Gruppe als aktiv gewaehlt. Daher kommt es mal raus.
+            //battle.setFiringShip(aship.getShip());
             battle.logme("Schiff: "+Battle.log_shiplink(aship.getShip())+"\n");
 
             if(enemyShip.getTypeData().getTypeId() != enemytypeid)


### PR DESCRIPTION
mittels der Funktion setFiringShip wurde im Battle-Objekt der Zeiger des aktiven Schiffs weiter gesetzt. Da die KSGroupAttackAction die Ballerei uebernimmt, braucht man den Zeiger nicht umzusetzen und erhaelt somit den Zeiger auf das anfangs gewaehtle Schiff bei.