### PR TITLE
fix: getBaseShip gibt jetzt das BaseShip zurueck

### DIFF
--- a/game/src/main/java/net/driftingsouls/ds2/server/battles/BattleShip.java
+++ b/game/src/main/java/net/driftingsouls/ds2/server/battles/BattleShip.java
@@ -552,7 +552,7 @@ public class BattleShip {
 	public BattleShip getBaseShip()
 	{
 		List<BattleShip> ownShips = getBattle().getOwnShips();
-		int shipid = getId();
+		int shipid = getShip().getBaseShip().getId();
 
 		for (BattleShip ownShip1 : ownShips) {
 				if (ownShip1.getId() == shipid) {


### PR DESCRIPTION
Durch einen Fehler (-.-) wurde das Schiff selbst, statt des BaseShips zurueckgegeben. Das wurde gefixt. 