### PR TITLE
Änderung des "Über Drifting Souls"-Fensters

### DIFF
--- a/game/src/main/templates/main.html
+++ b/game/src/main/templates/main.html
@@ -420,6 +420,7 @@
 <!-- Info -->
 <div id="infobox" class="gfxbox" style="display:none">
 	<div class="content">
+		<!-- (Kommentar: Auskommentiert, weil nicht mehr genutzt | stattdessen habe ich nun die Ankündigungen aus dem Forum verlinkt)
 		<h3>Version</h3>
 		<table>
 			<tbody>
@@ -427,12 +428,19 @@
 				<tr><td>Build</td><td id="build"></td></tr>
 				<tr><td>Commit</td><td id="commit"></td></tr>
 			</tbody>
-		</table>
-		<h3>Letzte Änderungen</h3>
+		</table> 
+		-->
+		<h3>Wichtige Informationen:</h3>
+		Alle Ankündigungen und Updates finden sich im Forum unter "Ankündigung", siehe <a href="http://ds.rnd-it.de/viewforum.php?f=8&sid=b3a03433ccfe523c46c29c464aa200ed">hier</a>.
+		Die AGB sind auf der Startseite zu finden oder unter <a href="https://ds2.drifting-souls.net/ds?module=portal&action=infosAgb">diesem Link</a>.
+		Das Impressum ist dort ebenfalls zu finden, siehe auch <a href="https://ds2.drifting-souls.net/ds?module=portal&action=impressum">hier</a>.
+		Die aktuellen Spielregeln des DS-Teams (Spielleitung) befinden sich ebenfalls im Forum, und zwar in <a href="http://ds.rnd-it.de/viewtopic.php?f=8&t=179&p=467#p467">diesem Thread</a>.
+		<!-- (Kommentar: Auskommentiert, weil nicht mehr genutzt | stattdessen habe ich nun die Ankündigungen aus dem Forum verlinkt)
 		<table id="commits" class="datatable">
 			<thead><tr><th></th><th>Commit</th><th>Beschreibung</th><th>von</th></tr></thead>
 			<tbody></tbody>
 		</table>
+		-->
 	</div>
 </div>
 


### PR DESCRIPTION
Entfernen alter, nicht mehr genutzter Einträge.
Hinzufügung der Verlinkung zu den Ankündigungen, den AGB, dem Impressum und den Spielregeln der Spielleitung.