### PR TITLE
Fraktionsmenü: GTU-Untermenü

### DIFF
--- a/game/src/main/templates/ersteigern.html
+++ b/game/src/main/templates/ersteigern.html
@@ -43,7 +43,7 @@
 				<li>{!link_to Einsatz melden, aktionMelden, faction:$global.faction}</li>
 			{/endif}
 			{if faction.other}
-				<li>{!link_to Sonstiges, other, faction:$global.faction}</li>
+				<li>{!link_to Handelspostenliste, other, faction:$global.faction}</li>
 			{/endif}
 		</ul>
 	</div>


### PR DESCRIPTION
"Sonstiges" in "Handelspostenliste" umbenannt