### PR TITLE
Scanuebersicht im Navigationsmenue

### DIFF
--- a/game/src/main/java/net/driftingsouls/ds2/server/modules/schiffplugins/SensorsDefault.java
+++ b/game/src/main/java/net/driftingsouls/ds2/server/modules/schiffplugins/SensorsDefault.java
@@ -315,11 +315,11 @@ public class SensorsDefault implements SchiffPlugin {
 			Ship aship = (Ship) ship1;
 			ShipTypeData ashiptype = aship.getTypeData();
 			ShipTypeData mastertype = aship.getBaseType();
-			if (aship.getOwner().getID() == user.getID()) //man selbst
+			if (aship.getOwner().getId() == user.getId()) //man selbst
 			{
 				ownShipList.add(aship);
 			}
-			else if (user.beziehungZu(aship.getOwner())== Relation.FRIEND) //Freunde
+			else if (user.getRelations().beziehungZu(aship.getOwner())== User.Relation.FRIEND) //Freunde
 			{
 				friendShipList.add(aship);
 			}

--- a/game/src/main/java/net/driftingsouls/ds2/server/modules/schiffplugins/SensorsDefault.java
+++ b/game/src/main/java/net/driftingsouls/ds2/server/modules/schiffplugins/SensorsDefault.java
@@ -318,6 +318,7 @@ public class SensorsDefault implements SchiffPlugin {
 			if (aship.getOwner().getId() == user.getId()) //man selbst
 			{
 				ownShipList.add(aship);
+				friendShipList.add(aship); //man ist auch mit sich selbst befreundet und das macht es unten einfacher in der Berechnung
 			}
 			else if (user.getRelations().beziehungZu(aship.getOwner())== User.Relation.FRIEND) //Freunde
 			{
@@ -794,13 +795,13 @@ public class SensorsDefault implements SchiffPlugin {
 			}
 		}
 		t.setVar("global.owncount", ownShipList.size());
-		t.setVar("global.friendcount", friendShipList.size());
+		t.setVar("global.friendcount", friendShipList.size()-ownShipList.size());
 		t.setVar("global.enemycount", enemyShipList.size());
 		if(shiptype.hasFlag(ShipTypeFlag.SRS_AWAC) || shiptype.hasFlag(ShipTypeFlag.SRS_EXT_AWAC) )
 		{
 			t.setVar("global.own.stable", isSecondRowStable(ownShipList));
 			t.setVar("global.enemy.stable", isSecondRowStable(enemyShipList));
-			t.setVar("global.friend.stable", isSecondRowStable(friendShipList.addAll(ownShipList)));
+			t.setVar("global.friend.stable", isSecondRowStable(friendShipList));
 		}
 
 	}

--- a/game/src/main/java/net/driftingsouls/ds2/server/modules/schiffplugins/SensorsDefault.java
+++ b/game/src/main/java/net/driftingsouls/ds2/server/modules/schiffplugins/SensorsDefault.java
@@ -307,12 +307,26 @@ public class SensorsDefault implements SchiffPlugin {
 		else {
 			ownfleetcount = 0;
 		}
-
+		List<Ship> ownShipList = new ArrayList<>();
+		List<Ship> friendShipList = new ArrayList<>();
+		List<Ship> enemyShipList = new ArrayList<>();
 		for (Object ship1 : ships)
 		{
 			Ship aship = (Ship) ship1;
 			ShipTypeData ashiptype = aship.getTypeData();
 			ShipTypeData mastertype = aship.getBaseType();
+			if (aship.getOwner().getID() == user.getID()) //man selbst
+			{
+				ownShipList.add(aship);
+			}
+			else if (user.beziehungZu(aship.getOwner())== Relation.FRIEND) //Freunde
+			{
+				friendShipList.add(aship);
+			}
+			else //alles andere ist feindlich
+			{
+				enemyShipList.add(aship);
+			}
 
 			final String typeGroupID = aship.getType() + "_" + aship.getOwner().getId();
 
@@ -779,6 +793,16 @@ public class SensorsDefault implements SchiffPlugin {
 				t.clear_record();
 			}
 		}
+		t.setVar("global.owncount", ownShipList.size());
+		t.setVar("global.friendcount", friendShipList.size());
+		t.setVar("global.enemycount", enemyShipList.size());
+		if(shiptype.hasFlag(ShipTypeFlag.SRS_AWAC) || shiptype.hasFlag(ShipTypeFlag.SRS_EXT_AWAC) )
+		{
+			t.setVar("global.own.stable", isSecondRowStable(ownShipList));
+			t.setVar("global.enemy.stable", isSecondRowStable(enemyShipList));
+			t.setVar("global.friend.stable", isSecondRowStable(friendShipList.addAll(ownShipList)));
+		}
+
 	}
 
 	private void outputBases(Parameters caller, User user,
@@ -1015,5 +1039,43 @@ public class SensorsDefault implements SchiffPlugin {
 						"global.jumps.name",	(jumps>1 ? "Subraumspalten":"Subraumspalte"));
 		}
 	}
+
+	/**
+	 * Prueft, ob die zweite Reihe stabil ist. Beruecksichtigt wird auf Wunsch
+	 * auch eine Liste von Schiffen, welche der Schlacht noch nicht begetreten sind
+	 * (unter der Annahme, dass gemaess Flags die Schiffe in der ersten bzw zweiten
+	 * Reihe landen wuerden).
+	 * @param shiplist Die Schiffsliste deren zweite Reihe geprueft werden soll
+	 * @return <code>true</code>, falls die zweite Reihe unter den Bedingungen stabil ist
+	 */
+	public boolean isSecondRowStable( List<Ship> shiplist) {
+
+		double owncaps = 0;
+		double secondrowcaps = 0;
+        for (Ship aship : shiplist) {
+
+            ShipTypeData type = aship.getTypeData();
+
+            double size = type.getSize();
+            if (type.hasFlag(ShipTypeFlag.SECONDROW)) {
+                if (!aship.isDocked() && !aship.isLanded()) {
+                    secondrowcaps += size;
+                }
+            }
+            else
+            {
+                if (size > ShipType.SMALL_SHIP_MAXSIZE) {
+                    double countedSize = size;
+                    if (type.getCrew() > 0) {
+                        countedSize *= (aship.getCrew() / ((double) type.getCrew()));
+                    }
+                    owncaps += countedSize;
+                }
+            }
+        }
+
+        return Double.valueOf(secondrowcaps).intValue() == 0 || Double.valueOf(owncaps).intValue() >= Double.valueOf(secondrowcaps).intValue() * 2;
+
+		}
 
 }

--- a/game/src/main/templates/schiff.sensors.default.html
+++ b/game/src/main/templates/schiff.sensors.default.html
@@ -2,6 +2,31 @@
 	<table width="100%" class="show" cellpadding="3" cellspacing="3" align="center">
 	<tr>
 		<td class="schiff" valign="middle">Sensoren</td>
+		<td><span style="font-weight:bold; color:#1aff05">F</span>:{global.owncount}
+			{if global.awac}
+				{if global.own.stable}
+					<img style="vertical-align:middle" src="data/interface/ks/secondrow.png" alt="" title="Ihre zweite Reihe w&auml;re im Moment stabil." />
+				{else}
+				<img style="vertical-align:middle" src="data/interface/ks/secondrow_unstable.png" alt="" title="Ihre zweite Reihe w&auml;re im Moment instabil und k&ouml;nnte daher vom Gegner &uuml;berrannt werden." />
+				{/endif}
+			{/endif}
+			<span style="font-weight:bold; color:#05eeff">F</span>:{global.friendcount}
+			{if global.awac}
+				{if global.friend.stable}
+					<img style="vertical-align:middle" src="data/interface/ks/secondrow.png" alt="" title="Eine zweite Reihe mit gemeinsam mit Ihren Verbuuml;ndeten w&auml;re im Moment stabil." />
+				{else}
+				<img style="vertical-align:middle" src="data/interface/ks/secondrow_unstable.png" alt="" title="Ihre zweite Reihe w&auml;re im Moment instabil und k&ouml;nnte daher vom Gegner &uuml;berrannt werden." />
+				{/endif}
+			{/endif}
+			<span style="font-weight:bold; color:#ff0505">F</span>:{global.enemycount}
+			{if global.awac}
+				{if global.enemy.stable}
+					<img style="vertical-align:middle" src="data/interface/ks/secondrow.png" alt="" title="Die zweite Reihe aller feindlicher Schiffe w&auml;re im Moment stabil." />
+				{else}
+				<img style="vertical-align:middle" src="data/interface/ks/secondrow_unstable.png" alt="" title="Die zweite Reihe aller feindlicher SChiffe w&auml;re im Moment instabil und k&ouml;nnte daher vom Gegner &uuml;berrannt werden." />
+				{/endif}
+			{/endif}
+		</td>
 	</tr>
 	<tr><td class="Border">
 	{if global.goodscan}


### PR DESCRIPTION
Anzeige von:
- Anzahl eigener Schiffe im Sektor
- Anzahl befreundeter  Schiffe im Sektor
- Anzahl feindlicher Schiffe im Sektor

und jeweils einer Stabilitätsprognose, falls das scannende Schiff ein AWAC-Tag hat