### PR TITLE
UserID-Suche auf pic umgestellt

### DIFF
--- a/game/src/main/java/net/driftingsouls/ds2/server/services/ComNetService.java
+++ b/game/src/main/java/net/driftingsouls/ds2/server/services/ComNetService.java
@@ -94,7 +94,7 @@ public class ComNetService
 				query = db.createQuery("from ComNetEntry entry where entry.text like :input and channel=:channel order by entry.post desc");
 				break;
 			case UserId:
-				query = db.createQuery("from ComNetEntry entry where entry.user.id=:input and channel=:channel order by entry.post desc");
+				query = db.createQuery("from ComNetEntry entry where entry.pic=:input and channel=:channel order by entry.post desc");
 				break;
 			default:
 				throw new IllegalArgumentException("Unbekannter Suchmodus '" + modus + "'");


### PR DESCRIPTION
Da sonst Posts gelöschter Spieler nicht mehr gefunden werden können (user.id gleich 0)