### PR TITLE
Rundungsfehler im KS, Automatisches Löschen von Werftqueue-Einträgen deaktiviert

### DIFF
--- a/game/src/main/java/net/driftingsouls/ds2/server/modules/ks/KSAttackAction.java
+++ b/game/src/main/java/net/driftingsouls/ds2/server/modules/ks/KSAttackAction.java
@@ -578,7 +578,7 @@ public class KSAttackAction extends BasicKSAction {
 				hit = 0;
 			}
 			else {
-				hit -= eShip.getShields()/absSchaden;
+				hit -= Math.ceil(eShip.getShields()/absSchaden);
 				eShip.setShields(0);
 				getBattleService().logme(battle,  "+ Schilde ausgefallen\n" );
 				logMsg.append("+ Schilde ausgefallen\n");

--- a/game/src/main/java/net/driftingsouls/ds2/server/services/ShipyardService.java
+++ b/game/src/main/java/net/driftingsouls/ds2/server/services/ShipyardService.java
@@ -324,17 +324,18 @@ public class ShipyardService {
                 aWerften.setLinkedWerft(null);
             }
 
-            // Die Werftauftraege der groessten Werft zuordnen oder
-            // (falls notwendig) loeschen
+            // Die Werftauftraege der groessten Werft zuordnen
             final WerftObject largest = werften.get(0).getWerftSlots() > werften.get(1).getWerftSlots() ? werften.get(0) : werften.get(1);
 
             List<WerftQueueEntry> entries = komplex.getBuildQueue();
             for (WerftQueueEntry entry : entries)
             {
-                if (entry.getSlots() <= largest.getWerftSlots())
-                {
-                    copyToWerft(entry, largest);
-                }
+                // if (entry.getSlots() <= largest.getWerftSlots())
+                // {
+                //     copyToWerft(entry, largest);
+                // }
+                // Auch zu grosse Eintraege duerfen mitgenommen werden - diese pausieren bis die Werft wieder Teil eines ausreichend großen Komplexes sind
+                copyToWerft(entry, largest);
                 komplex.removeQueueEntry(entry);
             }
 

--- a/game/src/main/java/net/driftingsouls/ds2/server/werften/WerftObject.java
+++ b/game/src/main/java/net/driftingsouls/ds2/server/werften/WerftObject.java
@@ -982,17 +982,18 @@ public abstract class WerftObject extends DSObject implements Locatable {
 				aWerften.linkedWerft = null;
 			}
 
-			// Die Werftauftraege der groessten Werft zuordnen oder
-			// (falls notwendig) loeschen
+			// Die Werftauftraege der groessten Werft zuordnen
 			final WerftObject largest = werften.get(0).getWerftSlots() > werften.get(1).getWerftSlots() ? werften.get(0) : werften.get(1);
 
 			List<WerftQueueEntry> entries = komplex.getBuildQueue();
 			for (WerftQueueEntry entry : entries)
 			{
-				if (entry.getSlots() <= largest.getWerftSlots())
-				{
-					entry.copyToWerft(largest);
-				}
+				// if (entry.getSlots() <= largest.getWerftSlots())
+				// {
+				// 	entry.copyToWerft(largest);
+				// }
+				// Auch zu grosse Eintraege duerfen mitgenommen werden - diese pausieren bis die Werft wieder Teil eines ausreichend großen Komplexes sind
+				entry.copyToWerft(largest);
 				komplex.removeQueueEntry(entry);
 			}
 


### PR DESCRIPTION
Die Anzahl der nötigen Treffer zum Ausschalten der Schilde wurde irrtümlicherweise abgerundet.

Fix: Alte Formel wiederhergestellt