### PR TITLE
Hotfixfix: Abfrage war genau falschrum.

### DIFF
--- a/game/src/main/java/net/driftingsouls/ds2/server/modules/FleetMgntController.java
+++ b/game/src/main/java/net/driftingsouls/ds2/server/modules/FleetMgntController.java
@@ -858,7 +858,7 @@ public class FleetMgntController extends Controller
 				.list();
 
 		shipyards.removeIf(ship -> ship.getTypeData().getWerft() == 0);
-		shipyards.removeIf(ship -> ship.getTypeData().getOneWayWerft() == null);
+		shipyards.removeIf(ship -> ship.getTypeData().getOneWayWerft() != null);
 
 		if (shipyards.isEmpty())
 		{


### PR DESCRIPTION
versehentlich nicht die Einwegwerften, sondern die normalen Werten raus genommen. Das gehoert natuerlich andersrum