### PR TITLE
fix: Funktion fuer den normalen Aufruf wird noch benoetigt

### DIFF
--- a/game/src/main/java/net/driftingsouls/ds2/server/modules/BaseController.java
+++ b/game/src/main/java/net/driftingsouls/ds2/server/modules/BaseController.java
@@ -257,8 +257,16 @@ public class BaseController extends Controller
 	 * Zeigt die Basis an.
 	 */
 	@Action(ActionType.AJAX)
+		public AjaxViewModel ajaxAction(@UrlParam(name="col") Base base) {
+		return ajaxAction(base, null);
+	}
+
+	/**
+	 * Zeigt die Basis fuer einen Scan an.
+	 */
+	@Action(ActionType.AJAX)
 	public AjaxViewModel ajaxAction(@UrlParam(name="col") Base base, Ship ship) {
-		boolean scan = ship == null;
+		boolean scan = ship != null;
 		if(!scan)
 		{
 			validate(base);


### PR DESCRIPTION
durch Hinzufuegen des Ship-Parameters konnte die Funktion nicht mehr ohne Uebergabe eines gueltigen Schiffes aufgerufen werden..