### PR TITLE
fix?: ScanAction eigenen Namen verpassen

### DIFF
--- a/game/src/main/java/net/driftingsouls/ds2/server/modules/BaseController.java
+++ b/game/src/main/java/net/driftingsouls/ds2/server/modules/BaseController.java
@@ -72,8 +72,12 @@ public class BaseController extends Controller
 	private void validate(Base base) {
 		User user = (User)getUser();
 
-		if( (base == null) || (base.getOwner() != user) ) {
+		if( base == null ) {
 			throw new ValidierungException("Die angegebene Kolonie existiert nicht", Common.buildUrl("default", "module", "basen") );
+		}
+		if (base.getOwner() != user)
+		{
+			throw new ValidierungException("Die angegebene Kolonie gehört nicht Ihnen", Common.buildUrl("default", "module", "basen") );
 		}
 
 		base.getCargo().setOption( Cargo.Option.LINKCLASS, "schiffwaren" );
@@ -433,15 +437,15 @@ public class BaseController extends Controller
 	 */
 	@Action(ActionType.DEFAULT)
 	public TemplateEngine defaultAction(@UrlParam(name = "col") Base base,  RedirectViewResult redirect) {
-		return defaultAction(base,  null, redirect);
-        }
+		return scanAction(base,  null, redirect);
+	}
 
 
 	/**
 	 * Zeigt die Basis an.
 	 */
 	@Action(ActionType.DEFAULT)
-	public TemplateEngine defaultAction(@UrlParam(name = "col") Base base, Ship ship, RedirectViewResult redirect) {
+	public TemplateEngine scanAction(@UrlParam(name = "col") Base base, Ship ship, RedirectViewResult redirect) {
 		boolean scan = ship != null;
 		int shipid = 0;
 		if (!scan)

--- a/game/src/main/templates/schiff.sensors.default.html
+++ b/game/src/main/templates/schiff.sensors.default.html
@@ -83,7 +83,7 @@
 			{if global.awac}<td class="show2">&nbsp;</td>{/endif}
 			<td class="show2" align="left">
 			{if global.astiscan}
-				<a class="greenborder tooltip" href="./ds?module=base&amp;col={base.id}&amp;ship={global.ship}">
+				<a class="greenborder tooltip" href="./ds?module=base&amp;action=scan&amp;col={base.id}&amp;ship={global.ship}">
 					<img src="data/interface/schiffe/asti_scan.gif" alt="scannen" />
 					<span class="ttcontent">
 						{base.name} f&uuml;r {global.astiscan.cost} Energie scannen.


### PR DESCRIPTION
keine Ahnung, ob das wirklich hilft, aber ich habe es jetzt mal umbenannt, da er nach dem letzten Merge scheinbar immer die defaultAction ohne den Schiffsparameter verwendet