### PR TITLE
Update HtmlOutputHandler.java

### DIFF
--- a/game/src/main/java/net/driftingsouls/ds2/server/framework/pipeline/controllers/HtmlOutputHandler.java
+++ b/game/src/main/java/net/driftingsouls/ds2/server/framework/pipeline/controllers/HtmlOutputHandler.java
@@ -67,7 +67,10 @@ public class HtmlOutputHandler extends OutputHandler
 		}
 		else
 		{
-			sb.append("<script src=\"./data/javascript/ds.js\" type=\"text/javascript\"></script>\n");
+			if(this.getAttributeString("module") != "main")
+			{
+				sb.append("<script src=\"./data/javascript/ds.js\" type=\"text/javascript\"></script>\n");
+			}
 		}
 		sb.append("<div id=\"error-placeholder\"></div>\n");
 	}


### PR DESCRIPTION
As of now, the main page containing the navigation and the iframe both have a reference to the js file leading to failed js calls from inside the iframe.

This might fix it, but could potentially break some js code inside the main window.