### PR TITLE
Update main.html

### DIFF
--- a/game/src/main/templates/main.html
+++ b/game/src/main/templates/main.html
@@ -486,6 +486,6 @@
 </div>
 
 <!-- Frame -->
-<iframe id="mainframe" name="main" scrolling="auto" frameborder="0" src="./ds?module=ueber" sandbox="allow-top-navigation allow-scripts allow-forms allow-same-origin">
+<iframe id="mainframe" name="main" scrolling="auto" frameborder="0" src="./ds?module=ueber">
 	Dein Browser unterstützt leider keine iFrames. Am besten installierst Du einen Browser neueren Datums, wie z.B. den <a class="forschinfo" href="http://www.mozilla.org">Mozilla Firefox</a>
 </iframe>


### PR DESCRIPTION
"Ein iframe, der sowohl "allow-scripts" als auch "allow-same-origin" für sein "sandbox"-Attribut gesetzt hat, kann seine Sandbox entfernen."

There is no reason for a sandbox attribute that contains allow-scripts and allow-same-origin. Removing it seems to remove issues with executing scripts.

This is an alternative fix for pull request #329