### PR TITLE
Update 10_jquery-ui.css

### DIFF
--- a/game/src/main/webapp/data/css/ui-darkness/10_jquery-ui.css
+++ b/game/src/main/webapp/data/css/ui-darkness/10_jquery-ui.css
@@ -128,3 +128,8 @@
 }
 
 *:focus { outline:none }
+
+.ui-dialog #shiptypeBox .content {
+    max-height: 1000px;
+    height: auto;
+}


### PR DESCRIPTION
Fix um die Scrollbalken zu entfernen, wenn man die Schiffsinfos als Modal öffnet.