### PR TITLE
fix?: Offiziersstatusreset im Tick

### DIFF
--- a/game/src/main/java/net/driftingsouls/ds2/server/tick/regular/AcademyTick.java
+++ b/game/src/main/java/net/driftingsouls/ds2/server/tick/regular/AcademyTick.java
@@ -170,5 +170,12 @@ public class AcademyTick extends TickController {
 			}
 		}
 		.execute();
+
+		//da es immer mal wieder zu Problemem mit Offizieren kommt, die gefunden werden, setzen wir den Trainingsstatus des Offiziers zurueck, wenn wir ihn nicht mehr in einem Trainingseintrag finden
+		List<Offizier> offiziere = Common.cast(db.createQuery("from offiziere where id not in (select training from academy_queue_entry)").list());
+		for(Offizier offizier : offiziere){
+				offizier.setTraining(false);
+		}
 	}
+
 }


### PR DESCRIPTION
Hier ein Versuch, um den Offiziersstatus einmal zur resetten, falls irgendwo was schief gelaufen ist.

@sgift passt das so bzgl. des MySQL-Querys? Magst da einmal drüberschauen?