### PR TITLE
Feature spoiltertag

### DIFF
--- a/game/src/main/java/net/driftingsouls/ds2/server/bbcodes/TagSpoiler.java
+++ b/game/src/main/java/net/driftingsouls/ds2/server/bbcodes/TagSpoiler.java
@@ -1,0 +1,40 @@
+/*
+ *	Drifting Souls 2
+ *	Copyright (c) 2006 Christopher Jung
+ *
+ *	This library is free software; you can redistribute it and/or
+ *	modify it under the terms of the GNU Lesser General Public
+ *	License as published by the Free Software Foundation; either
+ *	version 2.1 of the License, or (at your option) any later version.
+ *
+ *	This library is distributed in the hope that it will be useful,
+ *	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *	Lesser General Public License for more details.
+ *
+ *	You should have received a copy of the GNU Lesser General Public
+ *	License along with this library; if not, write to the Free Software
+ *	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package net.driftingsouls.ds2.server.bbcodes;
+
+import net.driftingsouls.ds2.server.framework.bbcode.BBCodeFunction;
+
+/**
+ * BBCode fuer Spoiler.
+ *
+ */
+public class TagSpoiler implements BBCodeFunction {
+    @Override
+    public String handleMatch(String content, String... values) {
+        // content contains the spoiler, no further values used
+        StringBuilder bbCode = new StringBuilder();
+
+        bbCode.append("<span class=\"spoiler\">");
+        bbCode.append(content);
+        bbCode.append("</span>");
+
+        return bbCode.toString();
+    }
+
+}

--- a/game/src/main/java/net/driftingsouls/ds2/server/modules/BBCodeViewController.java
+++ b/game/src/main/java/net/driftingsouls/ds2/server/modules/BBCodeViewController.java
@@ -71,6 +71,9 @@ public class BBCodeViewController extends Controller
 		codes.add("[resource=iID|0|0,PARAM]Anzahl[/resource]");
 		codes.add("Als PARAM kann i oder n angegeben werden, um nur den Namen oder nur das Bild anzeigen zu lassen. Das ,PARAM kann aber auch komplett weggelassen werden.");
 		codes.add("Beispiel f&uuml;r 5 Nahrung: [resource=i16|0|0]5[/resource]<br />");
+		codes.add("[spoiler]Spoilertext[/spoiler]");
+		codes.add("Text der mit einem Spoiler Tag versehen wurde wird ausgegraut und dem Benutzer erst angezeigt, wenn dieser mit der Maus darüber fährt.");
+		codes.add("Dieser sollte insbesondere dann verwendet werden, wenn Geschehnisse beschrieben werden, die generell unter \"Not save for work\" fallen<br />");
 	}
 
 	private TemplateViewResultFactory templateViewResultFactory;

--- a/game/src/main/resources/META-INF/services/net.driftingsouls.ds2.server.framework.bbcode.BBCodeFunction
+++ b/game/src/main/resources/META-INF/services/net.driftingsouls.ds2.server.framework.bbcode.BBCodeFunction
@@ -12,4 +12,5 @@
 	<bbcode tag="map" params="1" handler="net.driftingsouls.ds2.server.bbcodes.TagMap" />
 	<bbcode tag="medal" params="1" handler="net.driftingsouls.ds2.server.bbcodes.TagMedal" />
 	<bbcode tag="rang" params="1" handler="net.driftingsouls.ds2.server.bbcodes.TagRang" />
+	<bbcode tag="spoiler" params="1" handler="net.driftingsouls.ds2.server.bbcodes.TagSpoiler" />
 </bbcodes>

--- a/game/src/main/webapp/data/css/common/99_rest.css
+++ b/game/src/main/webapp/data/css/common/99_rest.css
@@ -352,3 +352,15 @@
 .werft .werkstatt select {
 	width:200px;
 }
+
+/* 
+	BBCode Funktionen
+*/
+.spoiler {
+	color: grey;
+	background-color: grey;
+}
+.spoiler :hover {
+	color: unset;
+	background-color: unset;
+}


### PR DESCRIPTION
Ein neuer Tag für BBCodes um Texte von CN Nachrichten als "Spoiler" zu markieren.
Dieser wird dann erst angezeigt, wenn der Benutzer mit der Maus darüber hovered.
Explizit zu empfehlen für alles was unter NSFW fällt.

Achtung: Nicht getestet. Ich hab z.Z. keine lokale Lauffähige Version von DS.