### PR TITLE
Anpassung Energieerzeugung

### DIFF
--- a/game/src/main/java/net/driftingsouls/ds2/server/tick/regular/SchiffsTick.java
+++ b/game/src/main/java/net/driftingsouls/ds2/server/tick/regular/SchiffsTick.java
@@ -455,8 +455,8 @@ public class SchiffsTick extends TickController {
 		if( e < shiptd.getEps() )
 		{
 			int rm = shiptd.getRm();
-			if( shiptd.getCrew() > 0 ) {
-				rm = (int)(rm * shipd.getCrew() / (double)shiptd.getCrew());
+			if( shiptd.getMinCrew() > 0 && shipd.getCrew() < shiptd.getMinCrew() ) {
+				rm = (int)(rm * shipd.getCrew() / (double)shiptd.getMinCrew());
 			}
 			int maxenergie = rm;
 


### PR DESCRIPTION
Alt: Energieerzeugung ist reduziert, wenn nicht die maximale Crew auf dem Schiff vorhanden ist
Neu: Energieerzeugung ist reduziert, wenn nicht die *minimale* Crew auf dem Schiff vorhanden ist

-> Somit können leere Personentransporter wieder anständig fliegen.