### PR TITLE
Update 60_basis.css

### DIFF
--- a/game/src/main/webapp/data/css/common/60_basis.css
+++ b/game/src/main/webapp/data/css/common/60_basis.css
@@ -76,10 +76,11 @@
 .buildingActions li {
 	margin:0px;
 	padding: 1px 0px 3px 0px;
+	display: flex;
+        flex-direction: row;
+        justify-content: space-between;
 }
-.buildingActions .action {
-	float:right;
-}
+
 
 .baseActions {
 	margin:0px;
@@ -373,6 +374,4 @@ div div.gfxbox {
 	margin-top: -21px;
 	margin-left: -10px;
 }
-
-
 


### PR DESCRIPTION
Fix für den Blitzbug in der Basenansicht. Statt float:right; wird jetzt auch hier Flexbox verwendet.