### PR TITLE
Update comm.js

### DIFF
--- a/game/src/main/webapp/data/javascript/modules/comm.js
+++ b/game/src/main/webapp/data/javascript/modules/comm.js
@@ -91,6 +91,7 @@ function actionSelectChange( newval ) {
 function showpm(pmid) {
 	DS.get({module: 'comm', action: 'showPm', pmid: pmid}, function(result) {
 		$('#pmviewer').empty().append($(result).filter('#pmcontent'));
+		$('#pm' + pmid).remove();
 	});
 }
 


### PR DESCRIPTION
Änderung, die das "NEU" an pms entfernt, wenn diese vom Server geladen und angezeigt werden.
Die Entfernung ist Teil der Callback-Funktion und sollte nur im Fall dass die Nachricht auch dargestellt wird erfolgen.