### PR TITLE
Weitere de-Hibernatisierung der Sternenkarte. Basen werden jetzt auch…

### DIFF
--- a/game/src/main/java/net/driftingsouls/ds2/server/bases/Base.java
+++ b/game/src/main/java/net/driftingsouls/ds2/server/bases/Base.java
@@ -1351,36 +1351,6 @@ public class Base implements Cloneable, Lifecycle, Locatable, Transfering, Feedi
 	}
 
 	/**
-	 * Ermittelt den Offset in Sektoren fuer die Darstellung des von
-	 * {@link #getBaseImage(net.driftingsouls.ds2.server.Location)} ermittelten Bildes.
-	 * Der ermittelte Offset ist immer Negativ oder <code>0</code> und stellt
-	 * die Verschiebung der Grafik selbst dar (vgl. CSS-Sprites).
-	 *
-	 * @param location Koordinate fuer die das Bild der Basis ermittelt werden soll.
-	 * @return Der Offset als Array (<code>[x,y]</code>)
-	 */
-	public int[] getBaseImageOffset(Location location)
-	{
-		return this.klasse.getSectorImageOffset(location, this.getLocation());
-	}
-
-	/**
-	 * Gibt das Bild der Basis zurueck.
-	 * Dabei werden Ausdehnung und Besitzer beruecksichtigt. Zudem
-	 * kann das zurueckgelieferte Bild mehrere Sektoren umfassen. Der korrekte
-	 * Offset zur Darstellung des angefragten Sektors kann mittels
-	 * {@link #getBaseImageOffset(net.driftingsouls.ds2.server.Location)}
-	 * ermittelt werden.
-	 *
-	 * @param location Koordinate fuer die das Bild der Basis ermittelt werden soll.
-	 * @return Der Bildstring der Basis oder einen Leerstring, wenn die Basis die Koordinaten nicht schneidet
-	 */
-	public String getBaseImage(Location location)
-	{
-		return this.klasse.getSectorImage(location, this.getLocation());
-	}
-
-	/**
 	 * @return The current amount of food on the object.
 	 */
 	@Override

--- a/game/src/main/java/net/driftingsouls/ds2/server/bases/BaseType.java
+++ b/game/src/main/java/net/driftingsouls/ds2/server/bases/BaseType.java
@@ -355,32 +355,11 @@ public class BaseType
 		this.largeImage = largeImage;
 	}
 
-	/**
-	 * Gibt das Bild der in einem Sektor der Sternenkarte zurueck.
-	 * Dabei wird die Ausdehnung beruecksichtigt. Zudem
-	 * kann das zurueckgelieferte Bild mehrere Sektoren umfassen. Der korrekte
-	 * Offset zur Darstellung des angefragten Sektors kann mittels
-	 * {@link #getSectorImageOffset(net.driftingsouls.ds2.server.Location,net.driftingsouls.ds2.server.Location)}
-	 * ermittelt werden.
-	 *
-	 * @param location Koordinate fuer die das Bild der Basis ermittelt werden soll.
-	 * @param baseLocation Die Koordinate der Basis (Mittelpunkt)
-	 * @return Der Bildstring der Basis oder einen Leerstring, wenn die Basis die Koordinaten nicht schneidet
-	 */
-	public String getSectorImage(Location location, Location baseLocation)
-	{
-		if(!location.sameSector(0, baseLocation, size))
-		{
-			return "";
-		}
 
-		return starmapImage;
-	}
 
 	/**
 	 * Gibt den Pfad zum Bild auf der Sternenkarte zurueck. Das Bild kann mehrere Sektoren umfassen. Fuer
 	 * die Abfrage zwecks Darstellung in einem Sektor sollte die Methode
-	 * {@link #getSectorImage(net.driftingsouls.ds2.server.Location, net.driftingsouls.ds2.server.Location)}
 	 * verwendet werden.
 	 * @return Der Pfad zum Bild
 	 */
@@ -398,40 +377,4 @@ public class BaseType
 		this.starmapImage = starmapImage;
 	}
 
-	/**
-	 * Ermittelt den Offset in Sektoren fuer die Darstellung des von
-	 * {@link #getSectorImage(net.driftingsouls.ds2.server.Location,net.driftingsouls.ds2.server.Location)} ermittelten Bildes.
-	 * Der ermittelte Offset ist immer Negativ oder <code>0</code> und stellt
-	 * die Verschiebung der Grafik selbst dar (vgl. CSS-Sprites).
-	 *
-	 * @param location Koordinate fuer die das Bild der Basis ermittelt werden soll.
-	 * @param baseLocation Die Koordinate der Basis (Mittelpunkt)
-	 * @return Der Offset als Array (<code>[x,y]</code>)
-	 */
-	public int[] getSectorImageOffset(Location location, Location baseLocation)
-	{
-		if( size == 0 || !location.sameSector(0, baseLocation, size))
-		{
-			return new int[] {0,0};
-		}
-
-		for(int by = baseLocation.getY() - getSize(); by <= baseLocation.getY() + getSize(); by++)
-		{
-			for(int bx = baseLocation.getX() - getSize(); bx <= baseLocation.getX() + getSize(); bx++)
-			{
-				Location loc = new Location(baseLocation.getSystem(), bx, by);
-
-				if( !baseLocation.sameSector(0, loc, getSize()))
-				{
-					continue;
-				}
-
-				if(location.equals(loc))
-				{
-					return new int[] {-bx+baseLocation.getX()-size, -by+baseLocation.getY()-size};
-				}
-			}
-		}
-		return new int[] {0,0};
-	}
 }

--- a/game/src/main/java/net/driftingsouls/ds2/server/map/AdminStarmap.java
+++ b/game/src/main/java/net/driftingsouls/ds2/server/map/AdminStarmap.java
@@ -1,11 +1,11 @@
 package net.driftingsouls.ds2.server.map;
 
 import net.driftingsouls.ds2.server.Location;
-import net.driftingsouls.ds2.server.bases.Base;
 import net.driftingsouls.ds2.server.config.StarSystem;
 import net.driftingsouls.ds2.server.entities.User;
 import net.driftingsouls.ds2.server.framework.ContextMap;
 import net.driftingsouls.ds2.server.framework.db.DBUtil;
+import net.driftingsouls.ds2.server.services.SingleUserRelationsService;
 
 import java.sql.SQLException;
 import java.util.HashMap;
@@ -31,6 +31,7 @@ public class AdminStarmap extends PublicStarmap
 	{
 		super(system, ausschnitt);
 
+		this.UserRelationsService = new SingleUserRelationsService(adminUser.getId());
 		this.adminUser = adminUser;
 		buildFriendlyData();
 	}
@@ -54,11 +55,11 @@ public class AdminStarmap extends PublicStarmap
 	@Override
 	public SectorImage getUserSectorBaseImage(Location location)
 	{
-		List<Base> positionBases = map.getBaseMap().get(location);
+		List<BaseData> positionBases = map.getBaseMap().get(location);
 		if(positionBases != null && !positionBases.isEmpty())
 		{
-			Base base = positionBases.get(0);
-			String img = base.getOverlayImage(location, adminUser, true);
+			BaseData base = positionBases.get(0);
+			String img = base.getOverlayImage(location, adminUser, true, this.UserRelationsService.isMutualFriendTo(base.getOwnerId()));
 			if( img != null ) {
 				return new SectorImage(img, 0, 0);
 			}
@@ -150,7 +151,7 @@ public class AdminStarmap extends PublicStarmap
 	@Override
 	public boolean isHasSectorContent(Location position)
 	{
-		List<Base> bases = map.getBaseMap().get(position);
+		List<BaseData> bases = map.getBaseMap().get(position);
 		return bases != null && !bases.isEmpty() || this.getShipImage(position) != null || map.getRockPositions().contains(position);
 	}
 

--- a/game/src/main/java/net/driftingsouls/ds2/server/map/BaseData.java
+++ b/game/src/main/java/net/driftingsouls/ds2/server/map/BaseData.java
@@ -1,0 +1,123 @@
+package net.driftingsouls.ds2.server.map;
+
+import net.driftingsouls.ds2.server.Locatable;
+import net.driftingsouls.ds2.server.Location;
+import net.driftingsouls.ds2.server.entities.User;
+import net.driftingsouls.ds2.server.framework.ContextMap;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class BaseData implements Locatable {
+    private final int system;
+    private final int x;
+    private final int y;
+    private final int size;
+    private final int ownerId;
+    private final int ownerAllyId;
+    private final String starmapImage;
+    public BaseData(int system, int x, int y, int ownerId, int ownerAllyId, int size, String starmapImage)
+    {
+        this.system = system;
+        this.x = x;
+        this.y = y;
+        this.size = size;
+        this.ownerId = ownerId;
+        this.ownerAllyId = ownerAllyId;
+        this.starmapImage = starmapImage;
+    }
+
+    @Override
+    public Location getLocation() {
+        return new Location(system, x, y);
+    }
+
+    public int getSize()
+    {
+        return size;
+    }
+    public int getOwnerId()
+    {
+        return ownerId;
+    }
+    public int getOwnerAllyId()
+    {
+        return ownerAllyId;
+    }
+
+    public int[] getSectorImageOffset(Location location, Location baseLocation)
+    {
+        if( size == 0 || !location.sameSector(0, baseLocation, size))
+        {
+            return new int[] {0,0};
+        }
+
+        for(int by = baseLocation.getY() - size; by <= baseLocation.getY() + size; by++)
+        {
+            for(int bx = baseLocation.getX() - size; bx <= baseLocation.getX() + size; bx++)
+            {
+                Location loc = new Location(baseLocation.getSystem(), bx, by);
+
+                if( !baseLocation.sameSector(0, loc, getSize()))
+                {
+                    continue;
+                }
+
+                if(location.equals(loc))
+                {
+                    return new int[] {-bx+baseLocation.getX()-size, -by+baseLocation.getY()-size};
+                }
+            }
+        }
+        return new int[] {0,0};
+    }
+
+    public String getSectorImage(Location location)
+    {
+        if(!location.sameSector(0, this.getLocation(), size))
+        {
+            return "";
+        }
+
+        return starmapImage;
+    }
+
+    public String getOverlayImage(Location location, User user, boolean scanned, boolean areMutualFriends)
+    {
+        if(!location.sameSector(0, getLocation(), size))
+        {
+            return null;
+        }
+
+        org.hibernate.Session db = ContextMap.getContext().getDB();
+        User nobody = (User)db.get(User.class, -1);
+        User zero = (User)db.get(User.class, 0);
+
+        if(size > 0)
+        {
+            return null;
+        }
+        else if(ownerId == user.getId())
+        {
+            return "data/starmap/asti_own/asti_own.png";
+        }
+        else if(((ownerId != 0) && (user.getAlly() != null) && (ownerAllyId == user.getAlly().getId()) && user.getAlly().getShowAstis()) ||
+                areMutualFriends)
+        {
+            return "data/starmap/asti_ally/asti_ally.png";
+        }
+        else if(scanned && ownerId != -1 && ownerId != 0)
+        {
+            return "data/starmap/asti_enemy/asti_enemy.png";
+        }
+        else if(scanned && ownerId != -1 || ownerId == 0)
+        {
+            return starmapImage;
+        }
+        else
+        {
+            return null;
+        }
+    }
+}

--- a/game/src/main/java/net/driftingsouls/ds2/server/map/PublicStarmap.java
+++ b/game/src/main/java/net/driftingsouls/ds2/server/map/PublicStarmap.java
@@ -19,14 +19,11 @@
 package net.driftingsouls.ds2.server.map;
 
 import net.driftingsouls.ds2.server.Location;
-import net.driftingsouls.ds2.server.bases.Base;
 import net.driftingsouls.ds2.server.config.StarSystem;
 import net.driftingsouls.ds2.server.entities.Nebel;
+import net.driftingsouls.ds2.server.services.SingleUserRelationsService;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
+import java.util.*;
 
 /**
  * Die allgemeine Sicht auf eine Sternenkarte ohne nutzerspezifische Anzeigen.
@@ -111,12 +108,12 @@ public class PublicStarmap
 		List<RenderedSectorImage> renderList = new ArrayList<>();
 		renderList.add(new RenderedSectorImage("data/starmap/space/space.png", 0, 0, RenderedSectorImage.DEFAULT_MASK));
 
-		List<Base> positionBases = map.getBaseMap().get(location);
+		var positionBases = map.getBaseMap().get(location);
 		if(positionBases != null && !positionBases.isEmpty())
 		{
-			Base base = positionBases.get(0);
-			int[] offset = base.getBaseImageOffset(location);
-			renderList.add(new RenderedSectorImage(base.getBaseImage(location), offset[0], offset[1], RenderedSectorImage.DEFAULT_MASK));
+			BaseData base = positionBases.get(0);
+			int[] offset = base.getSectorImageOffset(location, base.getLocation());
+			renderList.add(new RenderedSectorImage(base.getSectorImage(location), offset[0], offset[1], RenderedSectorImage.DEFAULT_MASK));
 		}
 
 		List<Starmap.JumpNode> positionNodes = map.getNodeMap().get(location);
@@ -192,4 +189,6 @@ public class PublicStarmap
 	{
 
 	}
+
+	protected SingleUserRelationsService UserRelationsService;
 }

--- a/game/src/main/java/net/driftingsouls/ds2/server/map/UserRelationData.java
+++ b/game/src/main/java/net/driftingsouls/ds2/server/map/UserRelationData.java
@@ -1,0 +1,18 @@
+package net.driftingsouls.ds2.server.map;
+
+
+public class UserRelationData {
+    private final int userId;
+    private final int targetId;
+    private final int status;
+    public UserRelationData(int userId, int targetId, int status)
+    {
+        this.userId = userId;
+        this.targetId = targetId;
+        this.status = status;
+    }
+
+    public int getUserId(){return userId;}
+    public int getTargetUserId(){return targetId;}
+    public int getStatus(){return status;}
+}

--- a/game/src/main/java/net/driftingsouls/ds2/server/services/SingleUserRelationsService.java
+++ b/game/src/main/java/net/driftingsouls/ds2/server/services/SingleUserRelationsService.java
@@ -1,0 +1,90 @@
+package net.driftingsouls.ds2.server.services;
+
+import net.driftingsouls.ds2.server.framework.ContextMap;
+import net.driftingsouls.ds2.server.framework.db.DBUtil;
+import net.driftingsouls.ds2.server.map.UserRelationData;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static net.driftingsouls.ds2.server.entities.jooq.tables.UserRelations.USER_RELATIONS;
+
+
+/**
+ * Diese Klasse ist dazu gedacht, die Beziehung eines einzelnen Users zu allen anderen, sowie die Beziehung aller anderen zu ihm zwischenzuspeichern.
+ * Aktuell dient diese Klasse nur dazu festzustellen ob Spieler befreundet sind.
+ * Ziel ist es, mehrere Abfragen zum Server zu vermeiden indem einmal alle relevant eingeschätzten Daten geladen werden.
+ */
+public class SingleUserRelationsService {
+    private final int userId;
+    public SingleUserRelationsService(int userId)
+    {
+        this.userId = userId;
+        getUserRelationData();
+    }
+
+    protected Map<Integer, ArrayList<UserRelationData>> userRelationData;
+    public Map<Integer, ArrayList<UserRelationData>> getUserRelationData()
+    {
+        if(this.userRelationData != null)
+        {
+            return this.userRelationData;
+        }
+        Map<Integer, ArrayList<UserRelationData>> userRelationData = new HashMap<>();
+        try(var conn = DBUtil.getConnection(ContextMap.getContext().getEM())) {
+            var db = DBUtil.getDSLContext(conn);
+            try
+                    (
+                            var userRelations = db
+                                    .selectFrom(USER_RELATIONS)
+                                    .where
+                                            (
+                                                    USER_RELATIONS.USER_ID.eq(userId)
+                                                            .or(USER_RELATIONS.TARGET_ID.eq(userId))
+                                            )
+                    )
+            {
+                var result = userRelations.fetch();
+
+                for(var row : result)
+                {
+                    var urd = new UserRelationData(row.getValue(USER_RELATIONS.USER_ID), row.getValue(USER_RELATIONS.TARGET_ID), row.getValue(USER_RELATIONS.STATUS));
+                    if(urd.getUserId() == userId) // Meine Beziehung zu anderen Spielern
+                    {
+                        if(!userRelationData.containsKey(urd.getTargetUserId()))
+                        {
+                            userRelationData.put(urd.getTargetUserId(), new ArrayList<>() );
+                        }
+                        userRelationData.get(urd.getTargetUserId()).add(urd);
+                    }
+                    else // Die Beziehung anderer Spieler zu mir
+                    {
+                        if(!userRelationData.containsKey(urd.getUserId()))
+                        {
+                            userRelationData.put(urd.getUserId(), new ArrayList<>() );
+                        }
+                        userRelationData.get(urd.getUserId()).add(urd);
+                    }
+                }
+                this.userRelationData=userRelationData;
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+
+        return userRelationData;
+    }
+
+    public boolean isMutualFriendTo(int targetId)
+    {
+        var userRelations = getUserRelationData();
+
+        boolean areMutalFriends = false;
+        if(userRelations.containsKey(targetId))  areMutalFriends = userRelations.get(targetId).stream().filter(x -> x.getStatus() == 2).collect(Collectors.toList()).size() == 2;
+
+        return areMutalFriends;
+    }
+}


### PR DESCRIPTION
… über jooq geladen.

Zusätzliche Einführung eines UserRelationsService -> lädt für einen User alle ihn betreffenden Beziehungen aus der Datenbank und erlaubt zu prüfen, ob zwei Nutzer verbündet sind. Weitere Funktionalität kann nach Bedarf erweitert werden.
 -> Das resultiert in deutlicher weniger Abfragen der User_Relations Tabelle als bisher, da mit einem Mal alle relevanten Daten geladen werden.