### PR TITLE
Hibernate aus TileCache entfernt.

### DIFF
--- a/game/src/main/java/net/driftingsouls/ds2/server/AdminCommands.java
+++ b/game/src/main/java/net/driftingsouls/ds2/server/AdminCommands.java
@@ -1486,7 +1486,7 @@ public class AdminCommands {
 
 			List<StarSystem> systems = Common.cast(ContextMap.getContext().getDB().createQuery("from StarSystem order by id asc").list());
 			for (StarSystem system: systems) {
-				TileCache tileCache = TileCache.forSystem(system);
+				TileCache tileCache = TileCache.forSystem(system.getID());
 				tileCache.resetCache();
 			}
 

--- a/game/src/main/java/net/driftingsouls/ds2/server/bases/Base.java
+++ b/game/src/main/java/net/driftingsouls/ds2/server/bases/Base.java
@@ -1041,6 +1041,7 @@ public class Base implements Cloneable, Lifecycle, Locatable, Transfering, Feedi
 
 		Integer[] bebauung = base.getBebauung();
 		Integer[] bebon = base.getActive();
+		var buildings = Building.getBuildings();
 
 		for( int o=0; o < base.getWidth() * base.getHeight(); o++ )
 		{
@@ -1049,7 +1050,7 @@ public class Base implements Cloneable, Lifecycle, Locatable, Transfering, Feedi
 				continue;
 			}
 
-			Building building = Building.getBuilding(bebauung[o]);
+			Building building = buildings.get(bebauung[o]);
 
 			if( !buildinglocs.containsKey(building.getId()) ) {
 				buildinglocs.put(building.getId(), o);

--- a/game/src/main/java/net/driftingsouls/ds2/server/bases/Building.java
+++ b/game/src/main/java/net/driftingsouls/ds2/server/bases/Building.java
@@ -83,6 +83,20 @@ public abstract class Building
 		return (Building) db.get(Building.class, id);
 	}
 
+	public static Map<Integer, Building> getBuildings()
+	{
+		var map = new HashMap<Integer, Building>();
+		org.hibernate.Session db = ContextMap.getContext().getDB();
+		List<Building> buildings = db.createQuery("from Building").list();
+
+		for(var building : buildings)
+		{
+			map.put(building.getId(), building);
+		}
+
+		return map;
+	}
+
 	@Id @GeneratedValue
 	private int id;
 	private int bewohner;

--- a/game/src/main/java/net/driftingsouls/ds2/server/entities/DynamicJumpNode.java
+++ b/game/src/main/java/net/driftingsouls/ds2/server/entities/DynamicJumpNode.java
@@ -178,7 +178,7 @@ public class DynamicJumpNode {
 
         // Force a tile cache reset, so we don't get shadow images of old JN positions
         if(resetTileCache) {
-            TileCache.forSystem(system).resetCache();
+            TileCache.forSystem(system.getID()).resetCache();
         }
     }
 }

--- a/game/src/main/java/net/driftingsouls/ds2/server/install/StarSystemContentGenerator.java
+++ b/game/src/main/java/net/driftingsouls/ds2/server/install/StarSystemContentGenerator.java
@@ -144,7 +144,7 @@ public class StarSystemContentGenerator
 
 		org.hibernate.Session db = ContextMap.getContext().getDB();
 		List<BaseType> baseTypes = Common.cast(db.createCriteria(BaseType.class).list());
-		TileCache.forSystem(sys).resetCache();
+		TileCache.forSystem(sys.getID()).resetCache();
 		fuelleSystemMitAsteroiden(sys, baseTypes.stream().filter((bt) -> bt.getSize() == 0).collect(Collectors.toList()), (size) -> (int) Math.pow(size, 0.6));
 		fuelleSystemMitAsteroiden(sys, baseTypes.stream().filter((bt) -> bt.getSize() > 0).collect(Collectors.toList()), (size) -> (int) Math.pow(size, 0.2));
 		fuelleSystemMitNebeln(sys);

--- a/game/src/main/java/net/driftingsouls/ds2/server/map/AdminStarmap.java
+++ b/game/src/main/java/net/driftingsouls/ds2/server/map/AdminStarmap.java
@@ -21,9 +21,9 @@ import static net.driftingsouls.ds2.server.entities.jooq.tables.FriendlyScanRang
 public class AdminStarmap extends PublicStarmap
 {
 	private final User adminUser;
-	public AdminStarmap(StarSystem system, User adminUser, MapArea mapArea)
+	public AdminStarmap(int systemId, User adminUser, MapArea mapArea)
 	{
-		super(system, mapArea);
+		super(systemId, mapArea);
 
 		this.UserRelationsService = new SingleUserRelationsService(adminUser.getId());
 		this.adminUser = adminUser;

--- a/game/src/main/java/net/driftingsouls/ds2/server/map/PlayerStarmap.java
+++ b/game/src/main/java/net/driftingsouls/ds2/server/map/PlayerStarmap.java
@@ -42,11 +42,11 @@ public class PlayerStarmap extends PublicStarmap
 	 * Legt eine neue Sicht an.
 	 *
 	 * @param user Der Spieler fuer den die Sicht gelten soll.
-	 * @param system Die ID des zugrunde liegenden Sternensystems.
+	 * @param systemId Die ID des zugrunde liegenden Sternensystems.
 	 */
-	public PlayerStarmap(User user, StarSystem system, MapArea mapArea)
+	public PlayerStarmap(User user, int systemId, MapArea mapArea)
 	{
-		super(system, mapArea);
+		super(systemId, mapArea);
 
 		this.user = user;
 		if(this.user == null)

--- a/game/src/main/java/net/driftingsouls/ds2/server/map/PublicStarmap.java
+++ b/game/src/main/java/net/driftingsouls/ds2/server/map/PublicStarmap.java
@@ -43,11 +43,11 @@ public class PublicStarmap
 
 	/**
 	 * Konstruktor.
-	 * @param system Die ID des Systems
+	 * @param systemId Die ID des Systems
 	 */
-	public PublicStarmap(StarSystem system, MapArea mapArea)
+	public PublicStarmap(int systemId, MapArea mapArea)
 	{
-		this.map = new Starmap(system.getID());
+		this.map = new Starmap(systemId);
 		if( mapArea != null ) {
 			this.map = new ClippedStarmap(this.map, mapArea);
 		}

--- a/game/src/main/java/net/driftingsouls/ds2/server/modules/MapController.java
+++ b/game/src/main/java/net/driftingsouls/ds2/server/modules/MapController.java
@@ -310,7 +310,7 @@ public class MapController extends Controller
 			tileY = 0;
 		}
 
-		TileCache cache = TileCache.forSystem(sys);
+		TileCache cache = TileCache.forSystem(sys.getID());
 		File tileCacheFile = cache.getTile(tileX, tileY);
 
 		try (InputStream in = new FileInputStream(tileCacheFile))
@@ -439,11 +439,11 @@ public class MapController extends Controller
 		var mapArea = new MapArea(xstart, xend - xstart, ystart, yend - ystart);
 		if (admin && hasPermission(WellKnownAdminPermission.STARMAP_VIEW))
 		{
-			content = new AdminStarmap(sys, user, mapArea);
+			content = new AdminStarmap(sys.getID(), user, mapArea);
 		}
 		else
 		{
-			content = new PlayerStarmap(user, sys, mapArea);
+			content = new PlayerStarmap(user, sys.getID(), mapArea);
 		}
 
 		json.size = new MapViewModel.SizeViewModel();

--- a/game/src/main/java/net/driftingsouls/ds2/server/modules/UeberController.java
+++ b/game/src/main/java/net/driftingsouls/ds2/server/modules/UeberController.java
@@ -148,9 +148,10 @@ public class UeberController extends Controller
 		String ticktime = getTickTime();
 
 		String race = "???";
-		if (Rassen.get().rasse(user.getRace()) != null)
+		var spezies = Rassen.get().rasse(user.getRace());
+		if (spezies != null)
 		{
-			race = Rassen.get().rasse(user.getRace()).getName();
+			race = spezies.getName();
 		}
 
 		int ticks = getContext().get(ContextCommon.class).getTick();
@@ -440,12 +441,11 @@ public class UeberController extends Controller
 		int bw = 0;
 		int bases = 0;
 
-		List<?> basen = db.createQuery("from Base where owner= :user order by id")
+		List<Base> basen = db.createQuery("from Base b left join fetch b.core where owner= :user order by b.id")
 				.setEntity("user", user)
 				.list();
-		for (Object aBasen : basen)
+		for (Base base : basen)
 		{
-			Base base = (Base) aBasen;
 			bases++;
 
 			BaseStatus basedata = Base.getStatus(base);

--- a/game/src/main/java/net/driftingsouls/ds2/server/modules/schiffplugins/NavigationDefault.java
+++ b/game/src/main/java/net/driftingsouls/ds2/server/modules/schiffplugins/NavigationDefault.java
@@ -160,7 +160,7 @@ public class NavigationDefault implements SchiffPlugin {
 				log.error(String.format("ship: %s -- unknown system: %s", data.getId(), sys));
 			} else {
 				var mapArea = new MapArea(x - 1, 3, y - 1, 3);
-				PlayerStarmap map = new PlayerStarmap(user, system, mapArea);
+				PlayerStarmap map = new PlayerStarmap(user, system.getID(), mapArea);
 
 				int tmp = 0;
 


### PR DESCRIPTION
Buildings werden nurnoch einmal (pro Basis) geladen um den Status einer Basis zu berechnen.