### PR TITLE
Spielregeln integriert und Verweise aufs Forum entfernt

### DIFF
--- a/game/src/main/templates/main.html
+++ b/game/src/main/templates/main.html
@@ -471,17 +471,38 @@
 			</tbody>
 		</table>
 		-->
-		<h3>Wichtige Informationen:</h3>
-		Alle Ankündigungen und Updates finden sich im Forum unter "Ankündigung", siehe <a href="http://ds.rnd-it.de/viewforum.php?f=8&sid=b3a03433ccfe523c46c29c464aa200ed">hier</a>.
-		Die AGB sind auf der Startseite zu finden oder unter <a href="https://ds2.drifting-souls.net/agb">diesem Link</a>.
-		Das Impressum ist dort ebenfalls zu finden, siehe auch <a href="https://ds2.drifting-souls.net/impressum">hier</a>.
-		Die aktuellen Spielregeln des DS-Teams (Spielleitung) befinden sich ebenfalls im Forum, und zwar in <a href="http://ds.rnd-it.de/viewtopic.php?f=8&t=179&p=467#p467">diesem Thread</a>.
-		<!-- (Kommentar: Auskommentiert, weil nicht mehr genutzt | stattdessen habe ich nun die Ankündigungen aus dem Forum verlinkt)
-		<table id="commits" class="datatable">
-			<thead><tr><th></th><th>Commit</th><th>Beschreibung</th><th>von</th></tr></thead>
-			<tbody></tbody>
-		</table>
-		-->
+				<h3>Wichtige Informationen:</h3>
+            <h4>Offizielle Angaben</h4>
+		Alle Ankündigungen und Updates finden sich im <em>Com-Net</em> unter <em>"Offizielles"</em>, alternativ siehe im <a href="https://discord.gg/NcGTv63">Discord-Server</a> unter <i>#ankündigung</i>.<br />
+		Die AGB sind auf der Startseite zu finden oder unter <a href="https://ds2.drifting-souls.net/agb">diesem Link</a>.<br />
+		Das Impressum ist dort ebenfalls zu finden, siehe auch <a href="https://ds2.drifting-souls.net/impressum">hier</a>.<br />
+		<br />
+            <h4>Die Aktuellen Spielregeln</h4>
+		Gemäß § 4 Abs. 5 AGB kann die Spielleitung (DS-Team) Spielregeln erlassen. Diese können jederzeit angepasst werden.<br/ >
+		<br/ >
+		Die aktuellen Verbote sind im Folgenden aufgelistet:<br/ >
+		<ul>
+			<li> das Vornehmen strafbarer und ordnungswidriger Handlungen</li>
+			<li> das Verwenden von Bildern, Videos, Texten und Ähnliches in PNs, CN-Beiträgen, Handelsinseraten, Allianzbeschreibungen, Allianz- und Spielerlogos und Ähnlichen, ohne die Rechte an diesen Sachen zu verfügen bzw. ohne dass diese gemeinfrei sind</li>
+			<li> die Übergabe von Schiffen an andere Spieler (oder NPCs), um einen Vorteil im Kampf gegen selbige und/oder deren Verbündete und/oder Dritte zu erhalten, z. B. um deren Kampfreihen vorsätzlich instabil zu machen oder eine künstliche Schlacht zu erzeugen, ohne deren ausdrückliches Einverständnis</li>
+			<li> das Erstellen künstlicher Schlachten durch Dritte bzw. mithilfe von Dritten, um die Schlachtkontrolle über Schiffe einer Konfliktpartei zu erhalten</li>
+			<li> das Erstellen und Aufrechterhalten von Schlachten, deren Zweck hauptsächlich darin besteht, Schiffe in Schlachten zu sichern (vor Angriffen zu schützen) oder einen Alarm aufrechtzuerhalten</li>
+			<li> generell das Aufrechterhalten von Schlachten von mehr als 10 Ticks ohne relevante Aktivität (Dokumentation im Schlachtlog)</li>
+			<li> die Übergabe von Schiffen an andere Spieler, um vorsätzlich deren Finanzen zu überstrapazieren, sodass Schiffe zum Piraten überlaufen oder überlaufen zu drohen</li>
+			<li> der Besitz mehrerer Okeanus-Schilde pro Account</li>
+			<li> das Auffstellen mehrerer Okeanus-Schilde in einem Sektor</li>
+			<li> das komplette Einschwärzen oder sonstiges Unsichtbarmachen des eigenen Ingame-Namens, des Allianznamens oder des Schiffnamens</li>
+			<li> die Zeichenkette <em>"[VAC]"</em> ans Ende des eigenen Ingame-Namens setzen und somit einen Urlaubsmodus vortäuschen</li>
+			<li> sich exakt oder täuschend ähnlich wie ein anderer Spieler oder NPC nennen (denselben oder einen zum Verwechseln ähnlichen Ingame-Namen annhemen)</li>
+			<li> sich <em>"Niemand"</em>, <em>"Administrator"</em>, <em>"Moderator"</em>, <em>"Entwickler"</em> oder in ähnlicher Weise umbenennen, sodass eine offizielle Stellung im DS2-Team vorgetäuscht werden kann</li>
+			<li> vortäuschen, eine offizielle Stelle im DS2-Team oder eine Stelle als NPC zu haben</li>
+			<li> andere Spieler nach deren Login-Daten fragen oder auf andere Weise an diese zu gelangen versuchen</li>
+			<li> das Imitieren offizieller oder automatischer Nachrichten (PN), z. B. <em>"Schlacht eröffnet"</em></li>
+			<li> das grundlose insb. repetitive Spammen von PNs, CN-Beiträgen oder Handelsinseraten</li>
+			<li> künstliche Werftschlangen erstellen: Schiffsbauaufträge in der Werftbauschlange immer wieder unter andere Aufträge setzen, damit die nicht ausgeführten Bauaufträge sich künstlich stapeln und nicht beendet werden, um die Aufträge im Bedarfsfall alle in kurzem Abstand beenden zu lassen</li>
+		</ul><br />
+		<u>Anmerkung:</u><br/>
+		Jedes Verhalten, welches bereits durch die AGB verboten ist, muss nicht noch einmal in den Spielregeln verboten werden. Bei einem Konflikt zwischen AGB und den Spielregeln gehen die AGB vor, siehe § 1 Abs. 2 AGB.
 	</div>
 </div>
 


### PR DESCRIPTION
Da sich offenbar niemand um das Forum kümmern kann oder möchte, habe ich die Verweise auf selbiges hier entfernt.
Zudem sind die Spielregeln, die bislang nur im Forum einsehbar waren, nun im Spiel aufgelistet, da sie aktuell im Forum aus o. g. Gründen nicht mehr für normale Nutzer einsehbar sind.
@sgift Ich kenne mich leider nicht mit HTML aus und habe mir das aus dem Internet zusammengereimt. Bitte mal checken, ob das so alles richtig ist. :) 
danke