### PR TITLE
Removed erroneous check that prevented mass escape

### DIFF
--- a/game/src/main/java/net/driftingsouls/ds2/server/modules/ks/KSMenuFluchtAction.java
+++ b/game/src/main/java/net/driftingsouls/ds2/server/modules/ks/KSMenuFluchtAction.java
@@ -112,7 +112,7 @@ public class KSMenuFluchtAction extends BasicKSMenuAction {
 
             if (!aship.hasFlag(BattleShipFlag.FLUCHT) && !aship.hasFlag(BattleShipFlag.DESTROYED) &&
                     !aship.hasFlag(BattleShipFlag.FLUCHT) && !ownShip.getShip().isLanded() && !ownShip.getShip().isDocked() && (aship.getShip().getEngine() > 0) &&
-                    !aship.getShip().isBattleAction() && gotone)
+                    gotone)
             {
 
                 fluchtidlist++;


### PR DESCRIPTION
Mass Escape Option was only shown if at least one ship (in class or total) had not yet fired. This did not the current behaviour for single ship escapes or the internal validation check of the escape action, making this strictly a GUI bug.